### PR TITLE
feat: add client-side auto-save

### DIFF
--- a/src/backend/static/autosave.js
+++ b/src/backend/static/autosave.js
@@ -1,0 +1,34 @@
+(function () {
+  const script = document.currentScript;
+  const surveyId = script.dataset.surveyId;
+  const form = document.querySelector("form");
+  if (!form || !surveyId) {
+    return;
+  }
+  const storageKey = `survey_${surveyId}_draft`;
+
+  const saved = localStorage.getItem(storageKey);
+  if (saved) {
+    try {
+      const values = JSON.parse(saved);
+      form.querySelectorAll("input[name='option']").forEach((el) => {
+        if (values.includes(el.value)) {
+          el.checked = true;
+        }
+      });
+    } catch (e) {
+      console.warn("Failed to parse saved survey data", e);
+    }
+  }
+
+  form.addEventListener("change", () => {
+    const selected = Array.from(
+      form.querySelectorAll("input[name='option']:checked")
+    ).map((el) => el.value);
+    localStorage.setItem(storageKey, JSON.stringify(selected));
+  });
+
+  form.addEventListener("submit", () => {
+    localStorage.removeItem(storageKey);
+  });
+})();

--- a/src/backend/templates/survey_details.html
+++ b/src/backend/templates/survey_details.html
@@ -23,6 +23,7 @@
       <button type="submit" class="btn btn-primary">Submit</button>
       <button type="cancel" class="btn btn-warning">Cancel</button>
   </form>
+  <script src="{{ url_for('static', filename='autosave.js') }}" data-survey-id="{{ survey.id }}"></script>
   </section>
  {% else %}
   <section>


### PR DESCRIPTION
## Summary
- add client-side auto-save script to store draft survey answers in localStorage
- include auto-save script on survey details page

## Testing
- `ruff check .`
- `black --check .`
- `pytest -o addopts=` (fails: KeyError: 'DBUSER')

------
https://chatgpt.com/codex/tasks/task_e_6893d8a9066c832c9af2e82f449b7241